### PR TITLE
Pega sempre o primeiro parâmetro

### DIFF
--- a/ip.bat
+++ b/ip.bat
@@ -1,8 +1,8 @@
 @echo off
 REM Seta os parametros para executar diretamente pelo terminal
 if "%1"=="dhcp" (goto dhcp)
-if "%2"=="casa" (goto casa)
-if "%3"=="pref" (goto prefeitura)
+if "%1"=="casa" (goto casa)
+if "%1"=="pref" (goto prefeitura)
 
 REM Titulo
 cls


### PR DESCRIPTION
Quando tentei executar a configuração da "casa" ele não funcionou pq estava entando pega o segundo parâmetro depois do script.
